### PR TITLE
Add index curation cron job

### DIFF
--- a/attributes/logstash.rb
+++ b/attributes/logstash.rb
@@ -25,3 +25,4 @@ end
 
 default['et_elk']['logstash']['plugins'] = %w(logstash-filter-alter logstash-input-beats)
 default['et_elk']['logstash']['version'] = '1:2.1.1-1'
+default['et_elk']['logstash']['index_cleanup_days'] = 30

--- a/metadata.rb
+++ b/metadata.rb
@@ -11,6 +11,8 @@ supports 'ubuntu', '>= 14.04'
 depends 'apt', '~> 2.0'
 depends 'java', '~> 1.0'
 depends 'runit', '~> 1.5'
+depends 'python'
+depends 'cron'
 
 depends 'elasticsearch', '= 2.1.1'
 depends 'storage', '~> 2.2'

--- a/recipes/logstash.rb
+++ b/recipes/logstash.rb
@@ -62,3 +62,18 @@ end
     end
   end
 end
+
+include_recipe 'python'
+python_pip 'elasticsearch-curator'
+
+# Curator job to clean up the old indices
+cron_d 'logstash_curator' do
+  minute 0
+  hour 23
+  command '/usr/local/bin/curator delete indices ' \
+          '--prefix logstash ' \
+          '--timestring %Y.%m.%d ' \
+          "--older-than #{node['et_elk']['logstash']['index_cleanup_days']} " \
+          '--time-unit days ' \
+          '--exclude kibana-int'
+end


### PR DESCRIPTION
Sets up the ES curator to remove any logstash indices that are > 30 days, keeping our ELK clusters healthy.